### PR TITLE
Fix CI OOM issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
   build-and-test-job:
     executor: build-and-test-executor
     parallelism: 5
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:


### PR DESCRIPTION
Due to some change in recent CI speedup (https://github.com/apple/axlearn/pull/688), we may see occasional OOM during CI check in. Bumping up the container size seems help here, validated in this PR:
https://app.circleci.com/pipelines/github/apple/axlearn/2956/workflows/6e64d0a4-b04a-4585-8412-a588f6517a4c/jobs/6500